### PR TITLE
Fixed downloading and filenames for fakes3.

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -122,11 +122,8 @@ module FakeS3
         response['Last-Modified'] = Time.iso8601(real_obj.modified_date).httpdate()
         response.header['ETag'] = "\"#{real_obj.md5}\""
 
-        content_disposition = request.query['response-content-disposition']
-        unless content_disposition.empty?
-          file_name = request.query['filename']
-          response.header['Content-Disposition'] = "#{content_disposition}; filename='#{file_name}'"
-        end
+        disposition = request.query['response-content-disposition']
+        response.header['Content-Disposition'] = disposition if disposition.present?
         response['Accept-Ranges'] = "bytes"
         response['Last-Ranges'] = "bytes"
         response['Access-Control-Allow-Origin'] = '*'

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -121,6 +121,10 @@ module FakeS3
 
         response['Last-Modified'] = Time.iso8601(real_obj.modified_date).httpdate()
         response.header['ETag'] = "\"#{real_obj.md5}\""
+        content_disposition = request.query['filename']
+        unless content_disposition.nil?
+          response.header['Content-Disposition'] = "attachment; filename='#{content_disposition}'"
+        end
         response['Accept-Ranges'] = "bytes"
         response['Last-Ranges'] = "bytes"
         response['Access-Control-Allow-Origin'] = '*'

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -121,9 +121,11 @@ module FakeS3
 
         response['Last-Modified'] = Time.iso8601(real_obj.modified_date).httpdate()
         response.header['ETag'] = "\"#{real_obj.md5}\""
-        content_disposition = request.query['filename']
-        unless content_disposition.nil?
-          response.header['Content-Disposition'] = "attachment; filename='#{content_disposition}'"
+
+        content_disposition = request.query['response-content-disposition']
+        unless content_disposition.empty?
+          file_name = request.query['filename']
+          response.header['Content-Disposition'] = "#{content_disposition}; filename='#{file_name}'"
         end
         response['Accept-Ranges'] = "bytes"
         response['Last-Ranges'] = "bytes"


### PR DESCRIPTION
Problem:
1. Files would not download at all.
2. Once we fixed downloading, the file names were mangled.

Solution:
1. Set the response header to include the content-disposition
if the request header wanted it set.
